### PR TITLE
Fix whatsNew presented before viewDidAppear.

### DIFF
--- a/SwiftHub/Modules/Main/HomeTabBarViewModel.swift
+++ b/SwiftHub/Modules/Main/HomeTabBarViewModel.swift
@@ -39,10 +39,11 @@ class HomeTabBarViewModel: ViewModel, ViewModelType {
             }
         }.asDriver(onErrorJustReturn: [])
 
-        let whatsNewItems = Driver.just(whatsNewManager.whatsNew())
+        let whatsNew = whatsNewManager.whatsNew()
+        let whatsNewItems = input.whatsNewTrigger.take(1).map { _ in whatsNew }
 
         return Output(tabBarItems: tabBarItems,
-                      openWhatsNew: whatsNewItems)
+                      openWhatsNew: whatsNewItems.asDriverOnErrorJustComplete())
     }
 
     func viewModel(for tabBarItem: HomeTabBarItem) -> ViewModel {


### PR DESCRIPTION
I found a minor issue that in `HomeTabBarController`, the `WhatsNewController` will be present at `viewDidLoad`, rather than `viewDidAppear`.

Actually, the `input.whatsNewTrigger` in `HomeTabBarViewModel` is not accessed at all, which should be considered as an issue and here is the fix.